### PR TITLE
fix: resolve dual-logger confusion in RunStdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ func main() {
     ctx := context.Background()
     logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
-    err := shellguard.RunStdio(ctx, shellguard.Config{}, logger)
+    err := shellguard.RunStdio(ctx, shellguard.Config{Logger: logger})
     if err != nil {
         os.Exit(1)
     }

--- a/cmd/shellguard/main.go
+++ b/cmd/shellguard/main.go
@@ -46,7 +46,7 @@ func run(ctx context.Context, logger *slog.Logger, args []string) error {
 }
 
 func runStdio(ctx context.Context, logger *slog.Logger) error {
-	err := shellguard.RunStdio(ctx, shellguard.Config{}, logger)
+	err := shellguard.RunStdio(ctx, shellguard.Config{Logger: logger})
 	if errors.Is(err, context.Canceled) {
 		return nil
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -150,6 +150,11 @@ func NewCore(registry map[string]*manifest.Manifest, runner Executor, logger *sl
 	return c
 }
 
+// Logger returns the logger used by this Core.
+func (c *Core) Logger() *slog.Logger {
+	return c.logger
+}
+
 func (c *Core) Connect(ctx context.Context, in ConnectInput) (map[string]any, error) {
 	if strings.TrimSpace(in.Host) == "" {
 		return nil, errors.New("host is required")
@@ -658,7 +663,7 @@ type ServerOptions struct {
 	Version string
 }
 
-func NewMCPServer(core *Core, logger *slog.Logger, opts ...ServerOptions) *mcp.Server {
+func NewMCPServer(core *Core, opts ...ServerOptions) *mcp.Server {
 	name := "shellguard"
 	version := "0.1.0"
 	if len(opts) > 0 {
@@ -669,7 +674,7 @@ func NewMCPServer(core *Core, logger *slog.Logger, opts ...ServerOptions) *mcp.S
 			version = opts[0].Version
 		}
 	}
-	srv := mcp.NewServer(&mcp.Implementation{Name: name, Version: version}, &mcp.ServerOptions{Logger: logger})
+	srv := mcp.NewServer(&mcp.Implementation{Name: name, Version: version}, &mcp.ServerOptions{Logger: core.Logger()})
 
 	mcp.AddTool(srv, &mcp.Tool{Name: "connect", Description: "Connect to a remote server via SSH"},
 		func(ctx context.Context, _ *mcp.CallToolRequest, in ConnectInput) (*mcp.CallToolResult, map[string]any, error) {
@@ -735,8 +740,8 @@ func NewMCPServer(core *Core, logger *slog.Logger, opts ...ServerOptions) *mcp.S
 	return srv
 }
 
-func RunStdio(ctx context.Context, core *Core, logger *slog.Logger, opts ...ServerOptions) error {
-	server := NewMCPServer(core, logger, opts...)
+func RunStdio(ctx context.Context, core *Core, opts ...ServerOptions) error {
+	server := NewMCPServer(core, opts...)
 	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		return fmt.Errorf("run mcp stdio server: %w", err)
 	}
@@ -744,8 +749,8 @@ func RunStdio(ctx context.Context, core *Core, logger *slog.Logger, opts ...Serv
 }
 
 // NewHTTPHandler returns an http.Handler serving MCP over SSE.
-func NewHTTPHandler(core *Core, logger *slog.Logger, opts ...ServerOptions) http.Handler {
-	srv := NewMCPServer(core, logger, opts...)
+func NewHTTPHandler(core *Core, opts ...ServerOptions) http.Handler {
+	srv := NewMCPServer(core, opts...)
 	return mcp.NewSSEHandler(func(_ *http.Request) *mcp.Server {
 		return srv
 	}, nil)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -616,7 +616,7 @@ func TestDownloadNameCollision(t *testing.T) {
 func TestNewMCPServerRegistersTools(t *testing.T) {
 	ctx := context.Background()
 	core := NewCore(basicRegistry(), newFakeRunner(), nil)
-	s := NewMCPServer(core, nil)
+	s := NewMCPServer(core)
 	c := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
 	t1, t2 := mcp.NewInMemoryTransports()
 	ss, err := s.Connect(ctx, t1, nil)
@@ -683,6 +683,22 @@ func TestNewCoreNilLoggerUsesDiscard(t *testing.T) {
 	core := NewCore(basicRegistry(), newFakeRunner(), nil)
 	if core.logger == nil {
 		t.Fatal("expected discard logger, got nil")
+	}
+}
+
+func TestCoreLoggerReturnsLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	core := NewCore(basicRegistry(), newFakeRunner(), logger)
+	if got := core.Logger(); got != logger {
+		t.Fatalf("Logger() = %v, want %v", got, logger)
+	}
+}
+
+func TestCoreLoggerReturnsDiscardWhenNil(t *testing.T) {
+	core := NewCore(basicRegistry(), newFakeRunner(), nil)
+	if got := core.Logger(); got == nil {
+		t.Fatal("Logger() should return discard logger, got nil")
 	}
 }
 

--- a/shellguard.go
+++ b/shellguard.go
@@ -92,15 +92,12 @@ func New(cfg Config) (*server.Core, error) {
 }
 
 // RunStdio creates a server from cfg and runs it over stdin/stdout.
-func RunStdio(ctx context.Context, cfg Config, logger *slog.Logger) error {
-	if cfg.Logger == nil {
-		cfg.Logger = logger
-	}
+func RunStdio(ctx context.Context, cfg Config) error {
 	core, err := New(cfg)
 	if err != nil {
 		return err
 	}
-	return server.RunStdio(ctx, core, logger, server.ServerOptions{
+	return server.RunStdio(ctx, core, server.ServerOptions{
 		Name:    cfg.Name,
 		Version: cfg.Version,
 	})


### PR DESCRIPTION
## Summary

Resolves #12.

Remove the standalone `logger *slog.Logger` parameter from `RunStdio` and related functions. Logger is now accepted exclusively via `Config.Logger`, eliminating the confusing dual-path where the standalone parameter was silently ignored if `cfg.Logger` was already set.

## Changes

- Add `Core.Logger()` getter method so downstream functions can access the logger stored in Core
- Remove `logger *slog.Logger` parameter from `NewMCPServer`, `server.RunStdio`, and `NewHTTPHandler` -- they now use `core.Logger()`
- Remove `logger *slog.Logger` parameter from `shellguard.RunStdio` and the `if cfg.Logger == nil` fallback
- Update `cmd/shellguard/main.go` to pass logger via `Config.Logger`
- Update README example code to reflect new API

## Tests

- [x] New tests added
- [x] Existing tests updated
- [x] All tests pass

### Test Coverage

- `TestCoreLoggerReturnsLogger` -- verifies `Logger()` returns the provided logger
- `TestCoreLoggerReturnsDiscardWhenNil` -- verifies `Logger()` returns discard logger when nil was passed to `NewCore`
- Updated `TestNewMCPServerRegistersTools` to use new signature

## Verification

- [x] `make build` passes
- [x] `make test` passes (all 10 packages)
- [x] `go vet ./...` passes
- [x] No debug artifacts
- [x] Changes scoped to issue

## Risks / Notes

- **Breaking API change**: `shellguard.RunStdio`, `server.RunStdio`, `server.NewMCPServer`, and `server.NewHTTPHandler` all have different signatures. Any external callers will need to update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined RunStdio and related function signatures by consolidating the logger parameter into the configuration structure, reducing the number of parameters needed.
  * Updated API documentation to reflect simplified usage patterns.

* **Tests**
  * Added unit tests for Core.Logger() method behavior and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->