### PR TITLE
docs: add SSH configuration, authentication, and host key verification guide

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,13 +206,15 @@ Multi-stage command validation engine. Key internal components:
 
 ### `ssh`
 
-SSH connection manager with retry logic. Key components:
+SSH connection manager with retry logic, authentication, config resolution, and host key verification. Key components:
 
-- **`SSHManager`** -- manages concurrent connections with mutex-protected state. Supports connection-per-host with implicit single-host resolution.
-- **`XCryptoDialer`** -- default SSH dialer using `golang.org/x/crypto/ssh`. Note: host key verification is currently disabled.
-- **`ShellQuote()` / `ReconstructCommand()`** -- the critical security boundary that neutralizes shell metacharacters.
+- **`ssh.go`** -- `SSHManager` manages concurrent connections with mutex-protected state. `XCryptoDialer` is the default dialer using `golang.org/x/crypto/ssh`.
+- **`auth.go`** -- Builds the authentication method chain: explicit key, ssh-agent, default key discovery.
+- **`resolve.go`** -- Reads `~/.ssh/config` to resolve host aliases, per-host user/port/identity settings.
+- **`hostkey.go`** -- Host key verification with three modes: `accept-new` (TOFU, default), `strict`, `off`.
+- **`reconstruct.go`** -- `ShellQuote()` / `ReconstructCommand()` -- the critical security boundary that neutralizes shell metacharacters.
 
-**Retry logic:** Retries on transient errors (connection reset, broken pipe, timeout, EOF) with configurable count and exponential backoff.
+**Retry logic:** Retries on transient errors (connection reset, broken pipe, timeout, EOF) with configurable count and exponential backoff. Host key verification failures are not retriable.
 
 ### `output`
 


### PR DESCRIPTION
## Summary

Resolves #28.

Documents ShellGuard's SSH subsystem for end users (README) and developers (ARCHITECTURE), covering the auth chain, SSH config resolution, host key verification modes, and configuration options.

## Changes

- **README.md**: Added "SSH Configuration" section with four subsections: Authentication (3-tier auth chain), SSH Config Support (supported/unsupported `~/.ssh/config` directives), Host Key Verification (accept-new/strict/off modes), and Configuration (YAML + environment variable reference table)
- **docs/ARCHITECTURE.md**: Updated `ssh` package section to reflect the current file structure (`auth.go`, `resolve.go`, `hostkey.go`, `reconstruct.go`), removed stale "host key verification is currently disabled" note, added note that host key verification failures are not retriable

## Tests

- [ ] New tests added — N/A (documentation-only change)
- [x] All tests pass

## Verification

- [x] Build passes (`make build`)
- [x] All tests pass (`make test`)
- [x] No debug artifacts
- [x] Changes scoped to issue (2 documentation files only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive SSH configuration guide added covering authentication methods, host key verification modes (accept-new, strict, off), and configuration precedence rules.
  * Architecture documentation expanded with detailed descriptions of SSH handling components and security configuration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->