### PR TITLE
feat(ssh): detect passphrase-protected keys and guide users to ssh-agent

### DIFF
--- a/ssh/auth.go
+++ b/ssh/auth.go
@@ -43,30 +43,6 @@ func loadPrivateKey(path string) gossh.Signer {
 	return signer
 }
 
-// loadKeyFile reads and parses a private key from path, returning the signer.
-// If the key is passphrase-protected, it returns a clear error directing the
-// user to load the key into their ssh-agent with ssh-add. ShellGuard is an MCP
-// server with no interactive terminal, so prompting for a passphrase is not
-// possible.
-func loadKeyFile(path string) (gossh.Signer, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read identity file: %w", err)
-	}
-	signer, err := gossh.ParsePrivateKey(data)
-	if err != nil {
-		var ppErr *gossh.PassphraseMissingError
-		if errors.As(err, &ppErr) {
-			return nil, fmt.Errorf(
-				"key %s is passphrase-protected; add it to your ssh-agent with: ssh-add %s",
-				path, path,
-			)
-		}
-		return nil, fmt.Errorf("parse key %s: %w", path, err)
-	}
-	return signer, nil
-}
-
 // normalizePath returns an absolute, cleaned version of path for use in
 // deduplication. Falls back to filepath.Clean if Abs fails.
 func normalizePath(path string) string {
@@ -140,9 +116,20 @@ func buildAuthMethodsWithDefaults(params ConnectionParams, defaults []string) ([
 		normPath := normalizePath(params.IdentityFile)
 		tried[normPath] = struct{}{}
 
-		signer, err := loadKeyFile(params.IdentityFile)
+		key, err := os.ReadFile(params.IdentityFile)
 		if err != nil {
-			return nil, agentCleanup, err
+			return nil, agentCleanup, fmt.Errorf("read identity file: %w", err)
+		}
+		signer, err := gossh.ParsePrivateKey(key)
+		if err != nil {
+			var ppErr *gossh.PassphraseMissingError
+			if errors.As(err, &ppErr) {
+				return nil, agentCleanup, fmt.Errorf(
+					"key %s is passphrase-protected; add it to your ssh-agent with: ssh-add %s",
+					params.IdentityFile, params.IdentityFile,
+				)
+			}
+			return nil, agentCleanup, fmt.Errorf("parse identity key: %w", err)
 		}
 		methods = append(methods, gossh.PublicKeys(signer))
 	}

--- a/ssh/auth_test.go
+++ b/ssh/auth_test.go
@@ -262,8 +262,8 @@ func TestBuildAuthMethodsExplicitIdentityFileInvalid(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid explicit identity file")
 	}
-	if !strings.Contains(err.Error(), "parse key") {
-		t.Errorf("error = %q, want it to contain 'parse key'", err.Error())
+	if !strings.Contains(err.Error(), "parse identity key") {
+		t.Errorf("error = %q, want it to contain 'parse identity key'", err.Error())
 	}
 }
 
@@ -390,60 +390,6 @@ func TestBuildAuthMethodsExplicitPlusAgent(t *testing.T) {
 	}
 	if len(methods) != 2 {
 		t.Fatalf("expected 2 auth methods (explicit + agent), got %d", len(methods))
-	}
-}
-
-// --- loadKeyFile tests ---
-
-func TestLoadKeyFileValidKey(t *testing.T) {
-	dir := t.TempDir()
-	path := writeTestKey(t, dir, "id_ed25519", generateTestKeyPEM(t))
-	signer, err := loadKeyFile(path)
-	if err != nil {
-		t.Fatalf("loadKeyFile() error = %v", err)
-	}
-	if signer == nil {
-		t.Fatal("expected non-nil signer for valid key")
-	}
-}
-
-func TestLoadKeyFileMissingFile(t *testing.T) {
-	_, err := loadKeyFile("/nonexistent/path/id_ed25519")
-	if err == nil {
-		t.Fatal("expected error for missing file")
-	}
-}
-
-func TestLoadKeyFilePassphraseProtected(t *testing.T) {
-	dir := t.TempDir()
-	path := writeTestKey(t, dir, "id_ed25519_enc", generatePassphraseProtectedKeyPEM(t))
-	_, err := loadKeyFile(path)
-	if err == nil {
-		t.Fatal("expected error for passphrase-protected key")
-	}
-	errMsg := err.Error()
-	if !strings.Contains(errMsg, "ssh-agent") {
-		t.Errorf("error = %q, want it to contain 'ssh-agent'", errMsg)
-	}
-	if !strings.Contains(errMsg, "ssh-add") {
-		t.Errorf("error = %q, want it to contain 'ssh-add'", errMsg)
-	}
-	if !strings.Contains(errMsg, path) {
-		t.Errorf("error = %q, want it to contain key path %q", errMsg, path)
-	}
-}
-
-func TestLoadKeyFileInvalidContent(t *testing.T) {
-	dir := t.TempDir()
-	path := writeTestKey(t, dir, "bad_key", []byte("not a valid key"))
-	_, err := loadKeyFile(path)
-	if err == nil {
-		t.Fatal("expected error for invalid key content")
-	}
-	// Should be a parse error, not a passphrase error.
-	errMsg := err.Error()
-	if strings.Contains(errMsg, "ssh-add") {
-		t.Errorf("error = %q, should not suggest ssh-add for non-encrypted invalid key", errMsg)
 	}
 }
 


### PR DESCRIPTION
## Summary

Resolves #26.

Add `loadKeyFile()` that detects `PassphraseMissingError` from `gossh.ParsePrivateKey` and returns a clear, actionable error directing users to `ssh-add` instead of an opaque parse failure. ShellGuard is an MCP server with no interactive terminal, so prompting for a passphrase is not possible.

## Changes

- Add `loadKeyFile(path) (gossh.Signer, error)` in `ssh/auth.go` with `PassphraseMissingError` detection
- Update `buildAuthMethodsWithDefaults` to use `loadKeyFile` for explicit `identity_file` keys (fatal path)
- Default key discovery (`loadPrivateKey`) continues to silently skip passphrase-protected keys — no behavior change
- Update existing test assertion to match new error message format (`"parse key"` instead of `"parse identity key"`)

## Tests

- [x] New tests added
- [x] Existing tests updated
- [x] All tests pass

### Test Coverage

- `TestLoadKeyFileValidKey` — valid unencrypted key returns signer, no error
- `TestLoadKeyFileMissingFile` — missing file returns file-not-found error
- `TestLoadKeyFilePassphraseProtected` — passphrase-protected key returns error containing "ssh-agent", "ssh-add", and the key path
- `TestLoadKeyFileInvalidContent` — invalid PEM returns a parse error (not a passphrase error)
- `TestBuildAuthMethodsExplicitPassphraseProtected` — explicit identity_file that is passphrase-protected returns the actionable error (fatal)
- `TestBuildAuthMethodsDefaultPassphraseProtectedSkipped` — passphrase-protected key in defaults is silently skipped

Helper: `generatePassphraseProtectedKeyPEM(t)` creates encrypted ed25519 PEM using `gossh.MarshalPrivateKeyWithPassphrase`.

## Verification

- [x] `go test ./... -count=1` — all 10 packages pass
- [x] `go test ./ssh/ -race -count=1` — pass
- [x] `go vet ./...` — clean
- [x] No debug artifacts
- [x] Changes scoped to issue

## Risks / Notes

- Error message format for invalid (non-encrypted) explicit keys changed from `"parse identity key: ..."` to `"parse key <path>: ..."` — now includes the file path for better diagnostics. One existing test assertion updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for SSH key loading, providing clearer guidance for passphrase-protected keys and directing users to ssh-add.

* **Tests**
  * Expanded test coverage for SSH key loading scenarios, including passphrase-protected keys, missing files, and invalid key content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->