### PR TITLE
fix: use raw URL for demo video so it renders on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Commands are restricted to a curated set of read-only tools. Destructive operati
 
 Here's a demo of ShellGuard with [OpenCode](https://opencode.ai) against a simulated server. It works extremely well against real servers too.
 
-<video src="docs/videos/shellguard-demo.mp4" controls width="100%"></video>
+<video src="https://raw.githubusercontent.com/jonchun/shellguard/refs/heads/main/docs/videos/shellguard-demo.mp4" controls width="100%"></video>
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Changes the demo video `<video>` src from a relative path to the raw.githubusercontent.com URL so GitHub's markdown renderer can serve and play the video.