### PR TITLE
feat: include hostname in execute response

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -12,6 +12,7 @@ const (
 )
 
 type CommandResult struct {
+	Host       string `json:"host"`
 	Stdout     string `json:"stdout"`
 	Stderr     string `json:"stderr"`
 	ExitCode   int    `json:"exit_code"`

--- a/server/server.go
+++ b/server/server.go
@@ -282,6 +282,7 @@ func (c *Core) Execute(ctx context.Context, in ExecuteInput) (output.CommandResu
 	)
 
 	truncated := c.Truncate(execRes.Stdout, execRes.Stderr, execRes.ExitCode, execRes.RuntimeMs, c.MaxOutputBytes)
+	truncated.Host = hostForState
 	return truncated, nil
 }
 


### PR DESCRIPTION
## Summary

- Adds a `Host` field to `output.CommandResult` so the execute response includes which host the command ran on
- Uses the resolved hostname (via `resolveHostForState`), so it works both when the caller specifies a host explicitly and when it's auto-resolved from a single active connection
- Adds two tests: one for explicit host, one for auto-resolved host

## Changes

- `output/output.go`: Add `Host string` field to `CommandResult`
- `server/server.go`: Set `truncated.Host = hostForState` after truncation
- `server/server_test.go`: Add `TestExecuteResponseIncludesExplicitHost` and `TestExecuteResponseIncludesResolvedHost`