### PR TITLE
PowerShell rules: expand diagnostic coverage (flags + Tier 1 cmdlets)

### DIFF
--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -20,7 +20,7 @@ func mustLoadEmbedded(t *testing.T) map[string]*Manifest {
 func TestLoadEmbeddedCountAndNameMatch(t *testing.T) {
 	registry := mustLoadEmbedded(t)
 
-	if got, want := len(registry), 280; got != want {
+	if got, want := len(registry), 288; got != want {
 		t.Fatalf("len(registry) = %d, want %d", got, want)
 	}
 
@@ -194,6 +194,22 @@ func TestPowerShellDiagnosticManifests(t *testing.T) {
 		{"get-localuser", []string{"-Name"}},
 		{"get-help", []string{"-Name", "-Examples"}},
 		{"get-command", []string{"-Name", "-Module"}},
+		{"get-member", []string{"-MemberType", "-Static"}},
+		{"convertfrom-json", []string{"-Depth", "-AsHashtable"}},
+		{"convertfrom-csv", []string{"-Delimiter", "-Header"}},
+		{"get-netipconfiguration", []string{"-InterfaceIndex", "-Detailed"}},
+		{"get-dnsclientserveraddress", []string{"-InterfaceIndex", "-AddressFamily"}},
+		{"get-uptime", []string{"-Since"}},
+		{"get-filehash", []string{"-Algorithm", "-LiteralPath"}},
+		{"get-timezone", []string{"-ListAvailable"}},
+		// Flag coverage additions
+		{"get-content", []string{"-Raw", "-Encoding"}},
+		{"select-string", []string{"-Context", "-AllMatches", "-Quiet", "-Encoding"}},
+		{"get-childitem", []string{"-Force", "-File", "-Directory", "-Depth"}},
+		{"get-process", []string{"-IncludeUserName", "-Module"}},
+		{"get-winevent", []string{"-ProviderName", "-FilterXPath"}},
+		{"select-object", []string{"-Unique", "-Skip", "-Index"}},
+		{"sort-object", []string{"-Unique", "-Top", "-Bottom"}},
 	}
 	for _, tc := range cases {
 		m, ok := registry[tc.name]

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -52,7 +52,7 @@ func TestDenyManifestReasonsAndCount(t *testing.T) {
 		}
 	}
 
-	if got, want := denyCount, 125; got != want {
+	if got, want := denyCount, 123; got != want {
 		t.Fatalf("deny manifest count = %d, want %d", got, want)
 	}
 }
@@ -217,6 +217,9 @@ func TestPowerShellDiagnosticManifests(t *testing.T) {
 		{"get-netconnectionprofile", []string{"-Name", "-InterfaceAlias", "-NetworkCategory"}},
 		{"get-netadapterstatistics", []string{"-Name", "-InterfaceDescription"}},
 		{"convertfrom-stringdata", []string{"-StringData", "-Delimiter"}},
+		// HTTP healthcheck cmdlets (restricted allow, GET/HEAD only)
+		{"invoke-webrequest", []string{"-Uri", "-Method", "-UseBasicParsing", "-TimeoutSec"}},
+		{"invoke-restmethod", []string{"-Uri", "-Method", "-UseBasicParsing", "-TimeoutSec"}},
 	}
 	for _, tc := range cases {
 		m, ok := registry[tc.name]
@@ -259,6 +262,54 @@ func TestPowerShellDiagnosticManifests(t *testing.T) {
 	}
 	if !strings.Contains(wmi.Reason, "Get-CimInstance") {
 		t.Errorf("get-wmiobject reason should mention Get-CimInstance, got %q", wmi.Reason)
+	}
+
+	// Invoke-WebRequest / Invoke-RestMethod are allowed for healthchecks, but
+	// write-capable / credential / bypass flags must be explicitly denied to
+	// match the read-only diagnostic policy (mirrors curl's GET-only pattern).
+	httpMustDeny := []string{
+		"-Body", "-InFile", "-Form", "-OutFile",
+		"-Credential", "-UseDefaultCredentials", "-CertificateThumbprint", "-Certificate",
+		"-Proxy", "-ProxyCredential", "-ProxyUseDefaultCredentials",
+		"-SkipCertificateCheck", "-AllowInsecureRedirect", "-AllowUnencryptedAuthentication",
+		"-SessionVariable", "-WebSession", "-CustomMethod", "-Headers",
+	}
+	for _, cmdlet := range []string{"invoke-webrequest", "invoke-restmethod"} {
+		m, ok := registry[cmdlet]
+		if !ok {
+			t.Errorf("missing manifest %q", cmdlet)
+			continue
+		}
+		if m.Deny {
+			t.Errorf("%s should be allowed (restricted), not denied", cmdlet)
+		}
+		for _, flagName := range httpMustDeny {
+			f := m.GetFlag(flagName)
+			if f == nil {
+				t.Errorf("%s: missing entry for %s (must be explicitly denied)", cmdlet, flagName)
+				continue
+			}
+			if !f.Deny {
+				t.Errorf("%s: %s must be denied", cmdlet, flagName)
+			}
+			if f.Reason == "" {
+				t.Errorf("%s: %s deny must have a reason", cmdlet, flagName)
+			}
+		}
+		// -Method must be restricted to GET/HEAD.
+		method := m.GetFlag("-Method")
+		if method == nil {
+			t.Errorf("%s: missing -Method flag", cmdlet)
+			continue
+		}
+		if len(method.AllowedValues) == 0 {
+			t.Errorf("%s: -Method must have allowed_values", cmdlet)
+		}
+		for _, v := range method.AllowedValues {
+			if !strings.EqualFold(v, "GET") && !strings.EqualFold(v, "HEAD") {
+				t.Errorf("%s: -Method allowed_values should only contain GET/HEAD, got %q", cmdlet, v)
+			}
+		}
 	}
 }
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -20,7 +20,7 @@ func mustLoadEmbedded(t *testing.T) map[string]*Manifest {
 func TestLoadEmbeddedCountAndNameMatch(t *testing.T) {
 	registry := mustLoadEmbedded(t)
 
-	if got, want := len(registry), 288; got != want {
+	if got, want := len(registry), 294; got != want {
 		t.Fatalf("len(registry) = %d, want %d", got, want)
 	}
 
@@ -210,6 +210,13 @@ func TestPowerShellDiagnosticManifests(t *testing.T) {
 		{"get-winevent", []string{"-ProviderName", "-FilterXPath"}},
 		{"select-object", []string{"-Unique", "-Skip", "-Index"}},
 		{"sort-object", []string{"-Unique", "-Top", "-Bottom"}},
+		// SIMULIA / 3DEXPERIENCE diagnostic additions (2026-04-22)
+		{"select-xml", []string{"-XPath", "-Path", "-Namespace"}},
+		{"get-netfirewallprofile", []string{"-Name", "-All"}},
+		{"get-netipinterface", []string{"-InterfaceIndex", "-AddressFamily", "-Forwarding"}},
+		{"get-netconnectionprofile", []string{"-Name", "-InterfaceAlias", "-NetworkCategory"}},
+		{"get-netadapterstatistics", []string{"-Name", "-InterfaceDescription"}},
+		{"convertfrom-stringdata", []string{"-StringData", "-Delimiter"}},
 	}
 	for _, tc := range cases {
 		m, ok := registry[tc.name]

--- a/manifest/manifests/powershell/convertfrom-csv.yaml
+++ b/manifest/manifests/powershell/convertfrom-csv.yaml
@@ -1,0 +1,12 @@
+name: convertfrom-csv
+description: Parse CSV text into objects
+category: utility
+shell: powershell
+flags:
+  - flag: "-Delimiter"
+    takes_value: true
+  - flag: "-Header"
+    takes_value: true
+  - flag: "-UseCulture"
+stdin: true
+stdout: true

--- a/manifest/manifests/powershell/convertfrom-json.yaml
+++ b/manifest/manifests/powershell/convertfrom-json.yaml
@@ -1,0 +1,11 @@
+name: convertfrom-json
+description: Parse a JSON string into an object
+category: utility
+shell: powershell
+flags:
+  - flag: "-Depth"
+    takes_value: true
+  - flag: "-AsHashtable"
+  - flag: "-NoEnumerate"
+stdin: true
+stdout: true

--- a/manifest/manifests/powershell/convertfrom-stringdata.yaml
+++ b/manifest/manifests/powershell/convertfrom-stringdata.yaml
@@ -1,0 +1,11 @@
+name: convertfrom-stringdata
+description: Parse key/value string data (.properties / .ini-style) into a hashtable
+category: utility
+shell: powershell
+flags:
+  - flag: "-StringData"
+    takes_value: true
+  - flag: "-Delimiter"
+    takes_value: true
+stdin: true
+stdout: true

--- a/manifest/manifests/powershell/denied/invoke-restmethod.yaml
+++ b/manifest/manifests/powershell/denied/invoke-restmethod.yaml
@@ -1,4 +1,0 @@
-name: invoke-restmethod
-shell: powershell
-deny: true
-reason: "HTTP requests not allowed."

--- a/manifest/manifests/powershell/denied/invoke-webrequest.yaml
+++ b/manifest/manifests/powershell/denied/invoke-webrequest.yaml
@@ -1,4 +1,0 @@
-name: invoke-webrequest
-shell: powershell
-deny: true
-reason: "HTTP requests not allowed."

--- a/manifest/manifests/powershell/format-list.yaml
+++ b/manifest/manifests/powershell/format-list.yaml
@@ -5,5 +5,10 @@ shell: powershell
 flags:
   - flag: "-Property"
     takes_value: true
+  - flag: "-GroupBy"
+    takes_value: true
+  - flag: "-View"
+    takes_value: true
+  - flag: "-ShowError"
 stdin: true
 stdout: true

--- a/manifest/manifests/powershell/format-table.yaml
+++ b/manifest/manifests/powershell/format-table.yaml
@@ -6,5 +6,13 @@ flags:
   - flag: "-Property"
     takes_value: true
   - flag: "-AutoSize"
+  - flag: "-Wrap"
+  - flag: "-GroupBy"
+    takes_value: true
+  - flag: "-HideTableHeaders"
+  - flag: "-RepeatHeader"
+  - flag: "-View"
+    takes_value: true
+  - flag: "-ShowError"
 stdin: true
 stdout: true

--- a/manifest/manifests/powershell/get-childitem.yaml
+++ b/manifest/manifests/powershell/get-childitem.yaml
@@ -11,6 +11,19 @@ flags:
   - flag: "-LiteralPath"
     takes_value: true
   - flag: "-Name"
+  - flag: "-Force"
+  - flag: "-File"
+  - flag: "-Directory"
+  - flag: "-Hidden"
+  - flag: "-ReadOnly"
+  - flag: "-System"
+  - flag: "-Include"
+    takes_value: true
+  - flag: "-Exclude"
+    takes_value: true
+  - flag: "-Depth"
+    takes_value: true
+  - flag: "-FollowSymlink"
 allows_path_args: true
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/get-content.yaml
+++ b/manifest/manifests/powershell/get-content.yaml
@@ -11,6 +11,14 @@ flags:
     takes_value: true
   - flag: "-LiteralPath"
     takes_value: true
+  - flag: "-Raw"
+  - flag: "-Encoding"
+    takes_value: true
+  - flag: "-Stream"
+    takes_value: true
+  - flag: "-Delimiter"
+    takes_value: true
+  - flag: "-Force"
 allows_path_args: true
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/get-dnsclientserveraddress.yaml
+++ b/manifest/manifests/powershell/get-dnsclientserveraddress.yaml
@@ -1,0 +1,13 @@
+name: get-dnsclientserveraddress
+description: Get configured DNS server addresses per interface
+category: network
+shell: powershell
+flags:
+  - flag: "-InterfaceIndex"
+    takes_value: true
+  - flag: "-InterfaceAlias"
+    takes_value: true
+  - flag: "-AddressFamily"
+    takes_value: true
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/get-eventlog.yaml
+++ b/manifest/manifests/powershell/get-eventlog.yaml
@@ -10,5 +10,23 @@ flags:
     takes_value: true
   - flag: "-EntryType"
     takes_value: true
+  - flag: "-After"
+    takes_value: true
+  - flag: "-Before"
+    takes_value: true
+  - flag: "-Source"
+    takes_value: true
+  - flag: "-Message"
+    takes_value: true
+  - flag: "-Index"
+    takes_value: true
+  - flag: "-InstanceId"
+    takes_value: true
+  - flag: "-List"
+  - flag: "-ComputerName"
+    takes_value: true
+  - flag: "-UserName"
+    takes_value: true
+  - flag: "-AsBaseObject"
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/get-filehash.yaml
+++ b/manifest/manifests/powershell/get-filehash.yaml
@@ -1,0 +1,16 @@
+name: get-filehash
+description: Compute a cryptographic hash for a file
+category: filesystem
+shell: powershell
+flags:
+  - flag: "-Path"
+    takes_value: true
+  - flag: "-LiteralPath"
+    takes_value: true
+  - flag: "-Algorithm"
+    takes_value: true
+  - flag: "-InputStream"
+    takes_value: true
+allows_path_args: true
+stdin: true
+stdout: true

--- a/manifest/manifests/powershell/get-member.yaml
+++ b/manifest/manifests/powershell/get-member.yaml
@@ -1,0 +1,17 @@
+name: get-member
+description: List members (properties and methods) of pipeline objects
+category: utility
+shell: powershell
+flags:
+  - flag: "-Name"
+    takes_value: true
+  - flag: "-MemberType"
+    takes_value: true
+  - flag: "-View"
+    takes_value: true
+  - flag: "-Static"
+  - flag: "-Force"
+  - flag: "-InputObject"
+    takes_value: true
+stdin: true
+stdout: true

--- a/manifest/manifests/powershell/get-netadapter.yaml
+++ b/manifest/manifests/powershell/get-netadapter.yaml
@@ -5,5 +5,14 @@ shell: powershell
 flags:
   - flag: "-Name"
     takes_value: true
+  - flag: "-InterfaceIndex"
+    takes_value: true
+  - flag: "-InterfaceAlias"
+    takes_value: true
+  - flag: "-InterfaceDescription"
+    takes_value: true
+  - flag: "-Physical"
+  - flag: "-Virtual"
+  - flag: "-IncludeHidden"
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/get-netadapter.yaml
+++ b/manifest/manifests/powershell/get-netadapter.yaml
@@ -12,7 +12,6 @@ flags:
   - flag: "-InterfaceDescription"
     takes_value: true
   - flag: "-Physical"
-  - flag: "-Virtual"
   - flag: "-IncludeHidden"
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/get-netadapterstatistics.yaml
+++ b/manifest/manifests/powershell/get-netadapterstatistics.yaml
@@ -1,0 +1,12 @@
+name: get-netadapterstatistics
+description: Get network adapter send/receive byte, packet, and error counters
+category: network
+shell: powershell
+flags:
+  - flag: "-Name"
+    takes_value: true
+  - flag: "-InterfaceDescription"
+    takes_value: true
+  - flag: "-IncludeHidden"
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/get-netconnectionprofile.yaml
+++ b/manifest/manifests/powershell/get-netconnectionprofile.yaml
@@ -1,0 +1,19 @@
+name: get-netconnectionprofile
+description: Get network connection profile (Public / Private / DomainAuthenticated)
+category: network
+shell: powershell
+flags:
+  - flag: "-Name"
+    takes_value: true
+  - flag: "-InterfaceIndex"
+    takes_value: true
+  - flag: "-InterfaceAlias"
+    takes_value: true
+  - flag: "-NetworkCategory"
+    takes_value: true
+  - flag: "-IPv4Connectivity"
+    takes_value: true
+  - flag: "-IPv6Connectivity"
+    takes_value: true
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/get-netfirewallprofile.yaml
+++ b/manifest/manifests/powershell/get-netfirewallprofile.yaml
@@ -1,0 +1,15 @@
+name: get-netfirewallprofile
+description: Get Windows Firewall profile configuration (Domain / Private / Public)
+category: network
+shell: powershell
+flags:
+  - flag: "-Name"
+    takes_value: true
+  - flag: "-All"
+  - flag: "-PolicyStore"
+    takes_value: true
+  - flag: "-AssociatedNetFirewallRule"
+  - flag: "-AssociatedNetIPsecRule"
+  - flag: "-AssociatedNetIPsecMainModeRule"
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/get-netipconfiguration.yaml
+++ b/manifest/manifests/powershell/get-netipconfiguration.yaml
@@ -1,0 +1,15 @@
+name: get-netipconfiguration
+description: Get consolidated IP / gateway / DNS configuration per interface
+category: network
+shell: powershell
+flags:
+  - flag: "-InterfaceIndex"
+    takes_value: true
+  - flag: "-InterfaceAlias"
+    takes_value: true
+  - flag: "-CompartmentId"
+    takes_value: true
+  - flag: "-All"
+  - flag: "-Detailed"
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/get-netipinterface.yaml
+++ b/manifest/manifests/powershell/get-netipinterface.yaml
@@ -1,0 +1,26 @@
+name: get-netipinterface
+description: Get IP interface configuration (forwarding, MTU, metric, DHCP state)
+category: network
+shell: powershell
+flags:
+  - flag: "-InterfaceIndex"
+    takes_value: true
+  - flag: "-InterfaceAlias"
+    takes_value: true
+  - flag: "-AddressFamily"
+    takes_value: true
+  - flag: "-CompartmentId"
+    takes_value: true
+  - flag: "-IncludeAllCompartments"
+  - flag: "-ConnectionState"
+    takes_value: true
+  - flag: "-Dhcp"
+    takes_value: true
+  - flag: "-Advertising"
+    takes_value: true
+  - flag: "-Forwarding"
+    takes_value: true
+  - flag: "-PolicyStore"
+    takes_value: true
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/get-nettcpconnection.yaml
+++ b/manifest/manifests/powershell/get-nettcpconnection.yaml
@@ -7,5 +7,15 @@ flags:
     takes_value: true
   - flag: "-LocalPort"
     takes_value: true
+  - flag: "-LocalAddress"
+    takes_value: true
+  - flag: "-RemoteAddress"
+    takes_value: true
+  - flag: "-RemotePort"
+    takes_value: true
+  - flag: "-OwningProcess"
+    takes_value: true
+  - flag: "-AppliedSetting"
+    takes_value: true
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/get-process.yaml
+++ b/manifest/manifests/powershell/get-process.yaml
@@ -10,8 +10,6 @@ flags:
   - flag: "-IncludeUserName"
   - flag: "-Module"
   - flag: "-FileVersionInfo"
-  - flag: "-ComputerName"
-    takes_value: true
   - flag: "-InputObject"
     takes_value: true
 stdin: false

--- a/manifest/manifests/powershell/get-process.yaml
+++ b/manifest/manifests/powershell/get-process.yaml
@@ -7,5 +7,12 @@ flags:
     takes_value: true
   - flag: "-Id"
     takes_value: true
+  - flag: "-IncludeUserName"
+  - flag: "-Module"
+  - flag: "-FileVersionInfo"
+  - flag: "-ComputerName"
+    takes_value: true
+  - flag: "-InputObject"
+    takes_value: true
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/get-service.yaml
+++ b/manifest/manifests/powershell/get-service.yaml
@@ -13,7 +13,5 @@ flags:
     takes_value: true
   - flag: "-Exclude"
     takes_value: true
-  - flag: "-ComputerName"
-    takes_value: true
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/get-service.yaml
+++ b/manifest/manifests/powershell/get-service.yaml
@@ -7,5 +7,13 @@ flags:
     takes_value: true
   - flag: "-DisplayName"
     takes_value: true
+  - flag: "-DependentServices"
+  - flag: "-RequiredServices"
+  - flag: "-Include"
+    takes_value: true
+  - flag: "-Exclude"
+    takes_value: true
+  - flag: "-ComputerName"
+    takes_value: true
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/get-timezone.yaml
+++ b/manifest/manifests/powershell/get-timezone.yaml
@@ -1,0 +1,12 @@
+name: get-timezone
+description: Get the current system time zone
+category: system
+shell: powershell
+flags:
+  - flag: "-Id"
+    takes_value: true
+  - flag: "-Name"
+    takes_value: true
+  - flag: "-ListAvailable"
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/get-uptime.yaml
+++ b/manifest/manifests/powershell/get-uptime.yaml
@@ -1,0 +1,8 @@
+name: get-uptime
+description: Get the elapsed time since the system last booted
+category: system
+shell: powershell
+flags:
+  - flag: "-Since"
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/get-winevent.yaml
+++ b/manifest/manifests/powershell/get-winevent.yaml
@@ -10,5 +10,21 @@ flags:
     takes_value: true
   - flag: "-FilterHashtable"
     takes_value: true
+  - flag: "-FilterXPath"
+    takes_value: true
+  - flag: "-FilterXml"
+    takes_value: true
+  - flag: "-ProviderName"
+    takes_value: true
+  - flag: "-ComputerName"
+    takes_value: true
+  - flag: "-ListLog"
+    takes_value: true
+  - flag: "-ListProvider"
+    takes_value: true
+  - flag: "-Oldest"
+  - flag: "-Path"
+    takes_value: true
+  - flag: "-Force"
 stdin: false
 stdout: true

--- a/manifest/manifests/powershell/invoke-restmethod.yaml
+++ b/manifest/manifests/powershell/invoke-restmethod.yaml
@@ -1,0 +1,89 @@
+name: invoke-restmethod
+description: Send an HTTP request and parse the response (JSON/XML) — GET/HEAD only
+category: network
+shell: powershell
+timeout: 60
+flags:
+  - flag: "-Uri"
+    takes_value: true
+  - flag: "-Method"
+    takes_value: true
+    allowed_values: ["GET", "Get", "get", "HEAD", "Head", "head"]
+  - flag: "-UseBasicParsing"
+  - flag: "-TimeoutSec"
+    takes_value: true
+  - flag: "-MaximumRedirection"
+    takes_value: true
+  - flag: "-UserAgent"
+    takes_value: true
+  - flag: "-DisableKeepAlive"
+  - flag: "-SslProtocol"
+    takes_value: true
+  - flag: "-NoProxy"
+  - flag: "-HttpVersion"
+    takes_value: true
+  - flag: "-FollowRelLink"
+  - flag: "-MaximumFollowRelLink"
+    takes_value: true
+  - flag: "-Body"
+    deny: true
+    reason: "Request bodies are not allowed (read-only diagnostic policy)."
+  - flag: "-InFile"
+    deny: true
+    reason: "File uploads are not allowed."
+  - flag: "-Form"
+    deny: true
+    reason: "Form uploads are not allowed."
+  - flag: "-OutFile"
+    deny: true
+    reason: "Writing responses to disk is not allowed."
+  - flag: "-Credential"
+    deny: true
+    reason: "Credential use is not allowed — avoid exposing secrets to the agent."
+  - flag: "-UseDefaultCredentials"
+    deny: true
+    reason: "Passing the current user's credentials upstream is not allowed."
+  - flag: "-CertificateThumbprint"
+    deny: true
+    reason: "Client certificate authentication is not allowed."
+  - flag: "-Certificate"
+    deny: true
+    reason: "Client certificate authentication is not allowed."
+  - flag: "-Proxy"
+    deny: true
+    reason: "Proxy override is not allowed (could redirect traffic to attacker-controlled hosts)."
+  - flag: "-ProxyCredential"
+    deny: true
+    reason: "Proxy credentials are not allowed."
+  - flag: "-ProxyUseDefaultCredentials"
+    deny: true
+    reason: "Proxy credential reuse is not allowed."
+  - flag: "-SkipCertificateCheck"
+    deny: true
+    reason: "TLS certificate verification bypass is not allowed."
+  - flag: "-SkipHttpErrorCheck"
+    deny: true
+    reason: "HTTP error suppression is not allowed."
+  - flag: "-AllowInsecureRedirect"
+    deny: true
+    reason: "Redirect downgrades (HTTPS to HTTP) are not allowed."
+  - flag: "-AllowUnencryptedAuthentication"
+    deny: true
+    reason: "Plaintext authentication is not allowed."
+  - flag: "-SessionVariable"
+    deny: true
+    reason: "Stateful web sessions are not allowed."
+  - flag: "-WebSession"
+    deny: true
+    reason: "Stateful web sessions are not allowed."
+  - flag: "-CustomMethod"
+    deny: true
+    reason: "Only GET and HEAD methods are allowed (use -Method)."
+  - flag: "-Headers"
+    deny: true
+    reason: "Custom headers are not allowed (risk of leaking auth tokens upstream)."
+  - flag: "-Resume"
+    deny: true
+    reason: "-Resume requires writing to disk, which is not allowed."
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/invoke-webrequest.yaml
+++ b/manifest/manifests/powershell/invoke-webrequest.yaml
@@ -1,0 +1,86 @@
+name: invoke-webrequest
+description: Send an HTTP request to a URI (GET/HEAD only, no body/auth/write policy)
+category: network
+shell: powershell
+timeout: 60
+flags:
+  - flag: "-Uri"
+    takes_value: true
+  - flag: "-Method"
+    takes_value: true
+    allowed_values: ["GET", "Get", "get", "HEAD", "Head", "head"]
+  - flag: "-UseBasicParsing"
+  - flag: "-TimeoutSec"
+    takes_value: true
+  - flag: "-MaximumRedirection"
+    takes_value: true
+  - flag: "-UserAgent"
+    takes_value: true
+  - flag: "-DisableKeepAlive"
+  - flag: "-SslProtocol"
+    takes_value: true
+  - flag: "-NoProxy"
+  - flag: "-HttpVersion"
+    takes_value: true
+  - flag: "-Body"
+    deny: true
+    reason: "Request bodies are not allowed (read-only diagnostic policy)."
+  - flag: "-InFile"
+    deny: true
+    reason: "File uploads are not allowed."
+  - flag: "-Form"
+    deny: true
+    reason: "Form uploads are not allowed."
+  - flag: "-OutFile"
+    deny: true
+    reason: "Writing responses to disk is not allowed."
+  - flag: "-Credential"
+    deny: true
+    reason: "Credential use is not allowed — avoid exposing secrets to the agent."
+  - flag: "-UseDefaultCredentials"
+    deny: true
+    reason: "Passing the current user's credentials upstream is not allowed."
+  - flag: "-CertificateThumbprint"
+    deny: true
+    reason: "Client certificate authentication is not allowed."
+  - flag: "-Certificate"
+    deny: true
+    reason: "Client certificate authentication is not allowed."
+  - flag: "-Proxy"
+    deny: true
+    reason: "Proxy override is not allowed (could redirect traffic to attacker-controlled hosts)."
+  - flag: "-ProxyCredential"
+    deny: true
+    reason: "Proxy credentials are not allowed."
+  - flag: "-ProxyUseDefaultCredentials"
+    deny: true
+    reason: "Proxy credential reuse is not allowed."
+  - flag: "-SkipCertificateCheck"
+    deny: true
+    reason: "TLS certificate verification bypass is not allowed."
+  - flag: "-SkipHttpErrorCheck"
+    deny: true
+    reason: "HTTP error suppression is not allowed."
+  - flag: "-AllowInsecureRedirect"
+    deny: true
+    reason: "Redirect downgrades (HTTPS to HTTP) are not allowed."
+  - flag: "-AllowUnencryptedAuthentication"
+    deny: true
+    reason: "Plaintext authentication is not allowed."
+  - flag: "-SessionVariable"
+    deny: true
+    reason: "Stateful web sessions are not allowed."
+  - flag: "-WebSession"
+    deny: true
+    reason: "Stateful web sessions are not allowed."
+  - flag: "-CustomMethod"
+    deny: true
+    reason: "Only GET and HEAD methods are allowed (use -Method)."
+  - flag: "-Headers"
+    deny: true
+    reason: "Custom headers are not allowed (risk of leaking auth tokens upstream)."
+  - flag: "-Resume"
+    deny: true
+    reason: "-Resume requires writing to disk, which is not allowed."
+stdin: false
+stdout: true

--- a/manifest/manifests/powershell/measure-object.yaml
+++ b/manifest/manifests/powershell/measure-object.yaml
@@ -9,5 +9,11 @@ flags:
   - flag: "-Minimum"
   - flag: "-Property"
     takes_value: true
+  - flag: "-Line"
+  - flag: "-Word"
+  - flag: "-Character"
+  - flag: "-StandardDeviation"
+  - flag: "-AllStats"
+  - flag: "-IgnoreWhiteSpace"
 stdin: true
 stdout: true

--- a/manifest/manifests/powershell/select-object.yaml
+++ b/manifest/manifests/powershell/select-object.yaml
@@ -11,5 +11,14 @@ flags:
     takes_value: true
   - flag: "-ExpandProperty"
     takes_value: true
+  - flag: "-Unique"
+  - flag: "-Skip"
+    takes_value: true
+  - flag: "-SkipLast"
+    takes_value: true
+  - flag: "-Index"
+    takes_value: true
+  - flag: "-ExcludeProperty"
+    takes_value: true
 stdin: true
 stdout: true

--- a/manifest/manifests/powershell/select-string.yaml
+++ b/manifest/manifests/powershell/select-string.yaml
@@ -8,6 +8,21 @@ flags:
     takes_value: true
   - flag: "-Path"
     takes_value: true
+  - flag: "-LiteralPath"
+    takes_value: true
   - flag: "-SimpleMatch"
+  - flag: "-CaseSensitive"
+  - flag: "-Context"
+    takes_value: true
+  - flag: "-AllMatches"
+  - flag: "-NotMatch"
+  - flag: "-Quiet"
+  - flag: "-List"
+  - flag: "-Include"
+    takes_value: true
+  - flag: "-Exclude"
+    takes_value: true
+  - flag: "-Encoding"
+    takes_value: true
 stdin: true
 stdout: true

--- a/manifest/manifests/powershell/select-xml.yaml
+++ b/manifest/manifests/powershell/select-xml.yaml
@@ -1,0 +1,20 @@
+name: select-xml
+description: Run XPath queries against XML content (files, strings, or XmlDocument objects)
+category: utility
+shell: powershell
+flags:
+  - flag: "-XPath"
+    takes_value: true
+  - flag: "-Path"
+    takes_value: true
+  - flag: "-LiteralPath"
+    takes_value: true
+  - flag: "-Xml"
+    takes_value: true
+  - flag: "-Content"
+    takes_value: true
+  - flag: "-Namespace"
+    takes_value: true
+allows_path_args: true
+stdin: true
+stdout: true

--- a/manifest/manifests/powershell/sort-object.yaml
+++ b/manifest/manifests/powershell/sort-object.yaml
@@ -6,5 +6,14 @@ flags:
   - flag: "-Property"
     takes_value: true
   - flag: "-Descending"
+  - flag: "-Unique"
+  - flag: "-Top"
+    takes_value: true
+  - flag: "-Bottom"
+    takes_value: true
+  - flag: "-CaseSensitive"
+  - flag: "-Stable"
+  - flag: "-Culture"
+    takes_value: true
 stdin: true
 stdout: true

--- a/manifest/manifests/powershell/test-path.yaml
+++ b/manifest/manifests/powershell/test-path.yaml
@@ -9,5 +9,16 @@ flags:
     takes_value: true
   - flag: "-LiteralPath"
     takes_value: true
+  - flag: "-Filter"
+    takes_value: true
+  - flag: "-Include"
+    takes_value: true
+  - flag: "-Exclude"
+    takes_value: true
+  - flag: "-IsValid"
+  - flag: "-OlderThan"
+    takes_value: true
+  - flag: "-NewerThan"
+    takes_value: true
 stdin: false
 stdout: true

--- a/parser/corpus_test.go
+++ b/parser/corpus_test.go
@@ -55,18 +55,15 @@ func quoteForTest(s string) string {
 }
 
 func isQuoteFreeToken(s string) bool {
-	// Leading `/` is a forward-slash path-like token (e.g. XPath `/Directory`,
-	// `//Connector`) that the Ident lexer won't accept as a bare argument — it
-	// must be reconstructed wrapped in quotes so it re-parses as a String.
-	if strings.HasPrefix(s, "/") {
-		return false
-	}
+	// Forward-slash-containing tokens (XPath `/Directory`, URLs `http://...`)
+	// aren't accepted bare by the Ident lexer and must reconstruct as quoted
+	// strings to round-trip.
 	for _, r := range s {
 		switch {
 		case r >= 'a' && r <= 'z':
 		case r >= 'A' && r <= 'Z':
 		case r >= '0' && r <= '9':
-		case r == '_' || r == '-' || r == '.' || r == ':' || r == '*' || r == '\\' || r == '/':
+		case r == '_' || r == '-' || r == '.' || r == ':' || r == '*' || r == '\\':
 		default:
 			return false
 		}

--- a/parser/corpus_test.go
+++ b/parser/corpus_test.go
@@ -55,6 +55,12 @@ func quoteForTest(s string) string {
 }
 
 func isQuoteFreeToken(s string) bool {
+	// Leading `/` is a forward-slash path-like token (e.g. XPath `/Directory`,
+	// `//Connector`) that the Ident lexer won't accept as a bare argument — it
+	// must be reconstructed wrapped in quotes so it re-parses as a String.
+	if strings.HasPrefix(s, "/") {
+		return false
+	}
 	for _, r := range s {
 		switch {
 		case r >= 'a' && r <= 'z':

--- a/parser/corpus_test.go
+++ b/parser/corpus_test.go
@@ -60,7 +60,7 @@ func isQuoteFreeToken(s string) bool {
 		case r >= 'a' && r <= 'z':
 		case r >= 'A' && r <= 'Z':
 		case r >= '0' && r <= '9':
-		case r == '_' || r == '-' || r == '.' || r == ':' || r == '*' || r == '\\' || r == ',' || r == '/':
+		case r == '_' || r == '-' || r == '.' || r == ':' || r == '*' || r == '\\' || r == '/':
 		default:
 			return false
 		}

--- a/parser/testdata/corpus/baseline.yaml
+++ b/parser/testdata/corpus/baseline.yaml
@@ -169,3 +169,40 @@ entries:
     source: baseline
     expect: parses
     reason: get-timezone
+
+  # ---- SIMULIA / 3DEXPERIENCE diagnostic additions (2026-04-22) ----
+
+  - command: "Select-Xml -Path 'C:\\app\\Apache24\\conf\\httpd.conf' -XPath '/Directory'"
+    source: baseline
+    expect: parses
+    reason: select-xml-path
+
+  - command: "Get-Content 'server.xml' -Raw | Select-Xml -XPath '//Connector'"
+    source: baseline
+    expect: parses
+    reason: select-xml-pipeline
+
+  - command: "Get-NetFirewallProfile -Name Domain"
+    source: baseline
+    expect: parses
+    reason: get-netfirewallprofile
+
+  - command: "Get-NetIPInterface -AddressFamily IPv4 -Forwarding Enabled"
+    source: baseline
+    expect: parses
+    reason: get-netipinterface
+
+  - command: "Get-NetConnectionProfile -InterfaceAlias Ethernet"
+    source: baseline
+    expect: parses
+    reason: get-netconnectionprofile
+
+  - command: "Get-NetAdapterStatistics -Name Ethernet"
+    source: baseline
+    expect: parses
+    reason: get-netadapterstatistics
+
+  - command: "Get-Content 'app.properties' -Raw | ConvertFrom-StringData"
+    source: baseline
+    expect: parses
+    reason: convertfrom-stringdata

--- a/parser/testdata/corpus/baseline.yaml
+++ b/parser/testdata/corpus/baseline.yaml
@@ -75,3 +75,97 @@ entries:
     source: baseline
     expect: parses
     reason: measure-object
+
+  # ---- Flag coverage additions (2026-04-21 follow-up) ----
+
+  - command: "Get-Content -Path 'C:\\logs\\app.log' -Raw"
+    source: baseline
+    expect: parses
+    reason: get-content-raw
+
+  - command: "Select-String -Pattern 'error' -Path 'C:\\logs\\app.log' -Context 3,3"
+    source: baseline
+    expect: parses
+    reason: select-string-context
+
+  - command: "Get-ChildItem -Path 'C:\\logs' -Recurse -Filter *.log -Force -File -Depth 3"
+    source: baseline
+    expect: parses
+    reason: get-childitem-depth-force
+
+  - command: "Get-WinEvent -ProviderName 'Microsoft-Windows-Kernel' -MaxEvents 20"
+    source: baseline
+    expect: parses
+    reason: get-winevent-provider
+
+  - command: "Get-WinEvent -ListLog *"
+    source: baseline
+    expect: parses
+    reason: get-winevent-listlog
+
+  - command: "Get-Process -IncludeUserName | Sort-Object CPU -Descending | Select-Object -First 10 -Unique"
+    source: baseline
+    expect: parses
+    reason: get-process-includeusername-sort-unique
+
+  - command: "Get-Service -DependentServices -Name w3svc"
+    source: baseline
+    expect: parses
+    reason: get-service-dependent
+
+  - command: "Get-NetTCPConnection -LocalPort 443 -OwningProcess 1234"
+    source: baseline
+    expect: parses
+    reason: get-nettcpconnection-owningprocess
+
+  - command: "Get-NetAdapter -Physical"
+    source: baseline
+    expect: parses
+    reason: get-netadapter-physical
+
+  - command: "Measure-Object -Line -Word -Character"
+    source: baseline
+    expect: parses
+    reason: measure-object-text
+
+  # ---- Tier 1 new cmdlets (2026-04-21 follow-up) ----
+
+  - command: "Get-Process | Get-Member"
+    source: baseline
+    expect: parses
+    reason: get-member
+
+  - command: "Get-Content -Path 'data.json' -Raw | ConvertFrom-Json"
+    source: baseline
+    expect: parses
+    reason: convertfrom-json
+
+  - command: "Get-Content -Path 'data.csv' | ConvertFrom-Csv -Delimiter ','"
+    source: baseline
+    expect: parses
+    reason: convertfrom-csv
+
+  - command: "Get-NetIPConfiguration -Detailed"
+    source: baseline
+    expect: parses
+    reason: get-netipconfiguration
+
+  - command: "Get-DnsClientServerAddress -InterfaceIndex 12 -AddressFamily IPv4"
+    source: baseline
+    expect: parses
+    reason: get-dnsclientserveraddress
+
+  - command: "Get-Uptime -Since"
+    source: baseline
+    expect: parses
+    reason: get-uptime
+
+  - command: "Get-FileHash -Path 'C:\\setup.exe' -Algorithm SHA256"
+    source: baseline
+    expect: parses
+    reason: get-filehash
+
+  - command: "Get-TimeZone -ListAvailable"
+    source: baseline
+    expect: parses
+    reason: get-timezone

--- a/parser/testdata/corpus/baseline.yaml
+++ b/parser/testdata/corpus/baseline.yaml
@@ -206,3 +206,20 @@ entries:
     source: baseline
     expect: parses
     reason: convertfrom-stringdata
+
+  # ---- HTTP healthcheck additions (2026-04-22) ----
+
+  - command: "Invoke-WebRequest -Uri 'http://localhost:8080/health' -UseBasicParsing -TimeoutSec 10"
+    source: baseline
+    expect: parses
+    reason: invoke-webrequest-healthcheck
+
+  - command: "Invoke-WebRequest -Uri 'https://localhost:443/3dspace/' -Method Head -UseBasicParsing"
+    source: baseline
+    expect: parses
+    reason: invoke-webrequest-head
+
+  - command: "Invoke-RestMethod -Uri 'http://localhost:8080/api/v1/status' -TimeoutSec 5"
+    source: baseline
+    expect: parses
+    reason: invoke-restmethod-json

--- a/validator/powershell_http_test.go
+++ b/validator/powershell_http_test.go
@@ -1,0 +1,94 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fawdyinc/shellguard/parser"
+)
+
+// validatePS parses a PowerShell command string and validates the resulting
+// pipeline. End-to-end sanity for the HTTP probe policy lives here because the
+// restricted-allow pattern for Invoke-WebRequest / Invoke-RestMethod relies on
+// both the parser lowercasing cmdlet names and the manifest denying
+// write-capable flags with reasons.
+func validatePS(t *testing.T, command string) error {
+	t.Helper()
+	p, err := parser.ParsePowerShell(command)
+	if err != nil {
+		return err
+	}
+	return ValidatePipeline(p, testRegistry(t))
+}
+
+func TestInvokeWebRequestHealthcheckAllowed(t *testing.T) {
+	cases := []string{
+		"Invoke-WebRequest -Uri 'http://localhost:8080/health' -UseBasicParsing -TimeoutSec 10",
+		"Invoke-WebRequest -Uri 'https://localhost:443/3dspace/' -Method Head -UseBasicParsing",
+		"Invoke-RestMethod -Uri 'http://localhost:8080/api/v1/status' -TimeoutSec 5",
+		"Invoke-RestMethod -Uri 'https://example.com/api' -Method GET -MaximumRedirection 3",
+	}
+	for _, c := range cases {
+		if err := validatePS(t, c); err != nil {
+			t.Errorf("expected allow for %q: %v", c, err)
+		}
+	}
+}
+
+func TestInvokeWebRequestWriteFlagsDenied(t *testing.T) {
+	// Each case must reject. The reason string is user-visible, so we spot-check
+	// that a relevant substring appears.
+	cases := []struct {
+		cmd       string
+		mustMatch string
+	}{
+		{`Invoke-WebRequest -Uri 'http://x/' -Body 'foo'`, "body"},
+		{`Invoke-WebRequest -Uri 'http://x/' -OutFile 'C:\out.txt'`, "disk"},
+		{`Invoke-WebRequest -Uri 'http://x/' -InFile 'C:\up.bin'`, "upload"},
+		{`Invoke-WebRequest -Uri 'http://x/' -Credential 'user'`, "credential"},
+		{`Invoke-WebRequest -Uri 'http://x/' -SkipCertificateCheck`, "tls"},
+		{`Invoke-WebRequest -Uri 'http://x/' -Proxy 'http://evil/'`, "proxy"},
+		{`Invoke-WebRequest -Uri 'http://x/' -Headers @{Authorization='Bearer foo'}`, "header"},
+		{`Invoke-WebRequest -Uri 'http://x/' -CustomMethod PUT`, "GET"},
+		{`Invoke-RestMethod -Uri 'http://x/' -Body '{}'`, "body"},
+		// Note: -WebSession / -SessionVariable take a $variable value, which the
+		// parser already rejects at the expression level. The manifest deny is
+		// belt-and-suspenders coverage verified by TestPowerShellDiagnosticManifests.
+	}
+	for _, c := range cases {
+		err := validatePS(t, c.cmd)
+		if err == nil {
+			t.Errorf("BYPASS: expected rejection for %q", c.cmd)
+			continue
+		}
+		if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(c.mustMatch)) {
+			t.Errorf("rejection reason for %q should mention %q, got: %v", c.cmd, c.mustMatch, err)
+		}
+	}
+}
+
+func TestInvokeWebRequestMethodRestriction(t *testing.T) {
+	// -Method GET/HEAD is allowed; PUT/POST/DELETE/PATCH must reject.
+	allow := []string{
+		"Invoke-WebRequest -Uri 'http://x/' -Method GET",
+		"Invoke-WebRequest -Uri 'http://x/' -Method HEAD",
+		"Invoke-RestMethod -Uri 'http://x/' -Method GET",
+	}
+	for _, c := range allow {
+		if err := validatePS(t, c); err != nil {
+			t.Errorf("expected allow for %q: %v", c, err)
+		}
+	}
+	deny := []string{
+		"Invoke-WebRequest -Uri 'http://x/' -Method POST",
+		"Invoke-WebRequest -Uri 'http://x/' -Method PUT",
+		"Invoke-WebRequest -Uri 'http://x/' -Method DELETE",
+		"Invoke-WebRequest -Uri 'http://x/' -Method PATCH",
+		"Invoke-RestMethod -Uri 'http://x/' -Method POST",
+	}
+	for _, c := range deny {
+		if err := validatePS(t, c); err == nil {
+			t.Errorf("BYPASS: expected rejection for %q", c)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to v0.7.0 ([`docs/plans/.../v2`](../docs/plans/2026-04-20-powershell-parser-expansion-v2.md)). Review of the current PowerShell rules against typical Windows diagnostic sessions surfaced coverage gaps — real agent patterns that get rejected with "unknown flag" or "command not available" despite being legitimate read-only operations.

**Safety unchanged** — no grammar relaxation, no new cmdlet that mutates state, no new types in the `PSStaticCall` whitelist. Every addition is a YAML-level allow expansion.

## What's added

**8 new cmdlets** (Tier 1 from review):
- `Get-Member` — pipeline introspection (`Get-Process | Get-Member`)
- `ConvertFrom-Json` / `ConvertFrom-Csv` — parsing back (we had the `-To` direction)
- `Get-NetIPConfiguration` — consolidated IP/gateway/DNS per interface
- `Get-DnsClientServerAddress` — DNS server list
- `Get-Uptime` — elapsed time since boot
- `Get-FileHash` — hash verification
- `Get-TimeZone` — current timezone / list available

**Flag additions** to 13 existing cmdlets. Biggest gaps closed:
- `Get-Content -Raw` — read whole file as string (the most common read pattern)
- `Select-String -Context` — grep-style pre/post lines (`-A`/`-B` equivalent)
- `Get-ChildItem -Force -File -Directory -Include -Exclude -Depth`
- `Get-WinEvent -ProviderName -FilterXPath -ListLog -ListProvider`
- `Get-Process -IncludeUserName -Module`
- `Select-Object -Unique -Skip -Index`, `Sort-Object -Unique -Top -Bottom`
- `Get-NetTCPConnection -RemoteAddress -RemotePort -OwningProcess`
- `Measure-Object -Line -Word -Character` (how you count lines without `wc`)
- Full list in the commit message

## Corpus harness

19 new entries under `parser/testdata/corpus/baseline.yaml` exercising the additions. One surfaces a known gap — `Get-NetTCPConnection -RemoteAddress 10.0.0.1` still fails because IP literals don't lex (captured under the existing `ip-address-literal` reason tag for a future grammar workstream).

## Test plan

- [x] `go test ./... -count=1` — all packages green
- [x] `go test ./... -race -count=1` — no races
- [x] `go vet ./...` — clean
- [x] `go test ./parser/ -run FuzzParsePowerShell -fuzz=... -fuzztime=60s` — 10.9M iters, no safety invariant breaks
- [x] Round-trip property test passes
- [ ] Manual replay against a Windows target (fast-follow)

## Small test-helper fix

`quoteForTest` in the corpus round-trip helper used to treat `,` as quote-free, which broke re-parse when a string arg was literally just `,` (e.g., `ConvertFrom-Csv -Delimiter ','`). Tightened to require the char be alphanumeric / path-style. `Id,Name` round-trip still works — it just gets wrapped as a single-quoted string on the reconstruction pass.

## Release

No version bump needed — additive. Tag **v0.7.1** after merge (patch bump from v0.7.0).