### PR TITLE
Unblock the last two commands from the 3DX session replay

### DIFF
--- a/manifest/manifests/powershell/get-psdrive.yaml
+++ b/manifest/manifests/powershell/get-psdrive.yaml
@@ -2,6 +2,15 @@ name: get-psdrive
 description: Get PowerShell drive information
 category: storage
 shell: powershell
-flags: []
+flags:
+  - flag: "-PSProvider"
+    takes_value: true
+    description: "Filter by provider, e.g. FileSystem or Registry."
+  - flag: "-Name"
+    takes_value: true
+    description: "Filter by drive name."
+  - flag: "-Scope"
+    takes_value: true
+    description: "Scope to query drives in."
 stdin: false
 stdout: true

--- a/parser/powershell.go
+++ b/parser/powershell.go
@@ -45,6 +45,13 @@ var psLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "DQString", Pattern: `"[^"]*"`},
 	// SizeLiteral must precede Number so `1GB` is one token, not `1` + `GB`.
 	{Name: "SizeLiteral", Pattern: `[0-9]+(?:KB|MB|GB|TB)`},
+	// IPLiteral must precede Number so `127.0.0.1` is one token. Otherwise
+	// Number matches `127` and the remaining `.0.0.1` is unlexable, because
+	// Ident must start with a letter — which is exactly how
+	// `Test-NetConnection -ComputerName 127.0.0.1` failed. Requiring all four
+	// octets keeps it from swallowing a decimal like `2.5`, which stays
+	// unsupported as before.
+	{Name: "IPLiteral", Pattern: `[0-9]{1,3}(?:\.[0-9]{1,3}){3}`},
 	{Name: "Number", Pattern: `[0-9]+`},
 	// Flag must precede Minus so `-Name` lexes as a flag token, not minus + ident.
 	{Name: "Flag", Pattern: `-[a-zA-Z_][a-zA-Z0-9_]*`},
@@ -104,6 +111,7 @@ type PSLiteral struct {
 	DQString  *string      `parser:"| @DQString"`
 	EnvRef    *string      `parser:"| @EnvRef"`
 	Size      *string      `parser:"| @SizeLiteral"`
+	IP        *string      `parser:"| @IPLiteral"`
 	Number    *string      `parser:"| @Number"`
 	Ident     *PSIdentish  `parser:"| @@"`
 }
@@ -731,6 +739,8 @@ func renderLiteral(l *PSLiteral) string {
 		return *l.EnvRef
 	case l.Size != nil:
 		return *l.Size
+	case l.IP != nil:
+		return *l.IP
 	case l.Number != nil:
 		return *l.Number
 	case l.Ident != nil:

--- a/parser/powershell_test.go
+++ b/parser/powershell_test.go
@@ -431,3 +431,50 @@ func TestParsePowerShell_WildcardIdent(t *testing.T) {
 		t.Errorf("expected '*.log', got %q", seg.Args[1])
 	}
 }
+
+// TestIPv4LiteralsParse covers `Test-NetConnection -ComputerName 127.0.0.1`,
+// which failed in the recorded 3DX session: Number matched `127` and the
+// remaining `.0.0.1` was unlexable because Ident must start with a letter.
+func TestIPv4LiteralsParse(t *testing.T) {
+	cases := []struct {
+		command string
+		wantArg string
+	}{
+		{"Test-NetConnection -ComputerName 127.0.0.1 -Port 443", "127.0.0.1"},
+		{"Test-NetConnection -ComputerName 10.20.30.40", "10.20.30.40"},
+		{"Test-NetConnection -ComputerName 255.255.255.255", "255.255.255.255"},
+	}
+	for _, tc := range cases {
+		p, err := ParsePowerShell(tc.command)
+		if err != nil {
+			t.Errorf("ParsePowerShell(%q) error = %v", tc.command, err)
+			continue
+		}
+		found := false
+		for _, a := range p.Segments[0].Args {
+			if a == tc.wantArg {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("ParsePowerShell(%q): args %v missing %q", tc.command, p.Segments[0].Args, tc.wantArg)
+		}
+	}
+}
+
+// TestIPLiteralDoesNotShadowExistingTokens guards the lexer ordering: the new
+// IPLiteral token sits before Number, so it must not swallow size literals,
+// arithmetic, or dotted property accessors.
+func TestIPLiteralDoesNotShadowExistingTokens(t *testing.T) {
+	cases := []string{
+		"Get-Volume | Select-Object DriveLetter, @{N='SizeGB';E={[math]::Round($_.Size/1GB,2)}}",
+		"Get-Content -Path 'C:\\logs\\a.log' -Tail 50",
+		"Get-Process | Select-Object -First 10",
+		"Get-ChildItem -Path 'C:\\Program Files'",
+	}
+	for _, c := range cases {
+		if _, err := ParsePowerShell(c); err != nil {
+			t.Errorf("ParsePowerShell(%q) error = %v", c, err)
+		}
+	}
+}

--- a/parser/testdata/corpus/session-3dx.yaml
+++ b/parser/testdata/corpus/session-3dx.yaml
@@ -3,7 +3,7 @@
 # As each workstream lands, flip `expect` on the affected entries and re-run
 # to see the delta. The grouping by `reason` tag drives prioritization.
 entries:
-  # ---- Already works ----
+  # ---- Already works (at the PARSER layer — see note on get-psdrive) ----
   - command: "Get-Service"
     source: ses_252a83796ffedk7cXAmutOY5tq
     expect: parses
@@ -14,6 +14,9 @@ entries:
     expect: parses
     reason: get-process-by-name
 
+  # This parsed all along, but the validator rejected -PSProvider until the
+  # get-psdrive manifest gained flags (it declared `flags: []`). A reminder that
+  # "parses" in this file never meant "runs".
   - command: "Get-PSDrive -PSProvider FileSystem"
     source: ses_252a83796ffedk7cXAmutOY5tq
     expect: parses
@@ -41,10 +44,13 @@ entries:
     expect: parses
     reason: double-quoted-literal-path
 
-  # ---- Fails today: manifest miss (Workstream D — grammar accepts, validator rejects) ----
-  # Note: these parse fine; the grammar doesn't gate on cmdlet identity. They're
-  # manifest-layer rejections, not parser rejections. Included here to widen the
-  # harness over time; for parser-only testing they all `parses`.
+  # ---- Formerly manifest misses (Workstream D) — now RESOLVED ----
+  # These parse fine; the grammar doesn't gate on cmdlet identity. They used to
+  # be rejected at the validator layer, which this parser-only corpus could not
+  # see. Case-insensitive cmdlet lookup fixed them: all now pass parse AND
+  # validate. Do not read the group heading as "still broken" — that staleness
+  # misled a later reader. Validator-level coverage now lives in
+  # validator/testdata/corpus/.
   - command: "Get-CimInstance Win32_Service"
     source: ses_252a83796ffedk7cXAmutOY5tq
     expect: parses
@@ -65,11 +71,11 @@ entries:
     expect: parses
     reason: test-netconnection-manifest-miss
 
-  # IP literals fail the lexer today (Number is [0-9]+, no dots).
-  # Real surprise from corpus run — flagged for a future workstream.
+  # Fixed: IPLiteral token added ahead of Number, so all four octets lex as
+  # one token instead of Number(127) plus an unlexable `.0.0.1`.
   - command: "Test-NetConnection -ComputerName 127.0.0.1 -Port 443"
     source: synthetic
-    expect: rejects
+    expect: parses
     reason: ip-address-literal
 
   - command: "Get-Process | ForEach-Object ProcessName"

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -713,3 +713,31 @@ func TestDangerousWindowsBinariesDeniedWithReason(t *testing.T) {
 		}
 	}
 }
+
+// TestGetPSDriveProviderFlag covers a command from the recorded 3DX session.
+// The manifest declared `flags: []`, so -PSProvider was rejected even though
+// the command parsed — the parser corpus called this entry "already works",
+// which was true of the parser and false of the validator.
+func TestGetPSDriveProviderFlag(t *testing.T) {
+	if err := validateOne(t, "Get-PSDrive", "-PSProvider", "FileSystem"); err != nil {
+		t.Errorf("Get-PSDrive -PSProvider FileSystem: unexpected error %v", err)
+	}
+	if err := validateOne(t, "get-psdrive"); err != nil {
+		t.Errorf("bare get-psdrive: unexpected error %v", err)
+	}
+	if err := validateOne(t, "Get-PSDrive", "-NotAReal", "x"); err == nil {
+		t.Error("unknown flag should still be rejected")
+	}
+}
+
+// TestIPLiteralReachesValidator confirms the parser change lands end to end:
+// an IPv4 flag value now survives parse and validate together.
+func TestIPLiteralReachesValidator(t *testing.T) {
+	p, err := parser.ParsePowerShell("Test-NetConnection -ComputerName 127.0.0.1 -Port 443")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := ValidatePipeline(p, testRegistry(t)); err != nil {
+		t.Errorf("validate: unexpected error %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Replaying `parser/testdata/corpus/session-3dx.yaml` end to end — parse **and** validate,
not parse alone — left 4 of 17 commands from the recorded 3DEXPERIENCE session blocked.
Two were real defects, and both had been invisible because the only harness was
parser-level.

## What changed

**`get-psdrive` declared `flags: []`.** `Get-PSDrive -PSProvider FileSystem` parsed fine
and was then rejected by the validator. The corpus filed this command under *"Already
works"* — true of the parser, false of the validator. Added `-PSProvider`, `-Name`, and
`-Scope`.

**IPv4 literals failed the lexer.** `Number` is `[0-9]+` with no dots, so `127.0.0.1`
matched `127` and left an unlexable `.0.0.1`, because `Ident` must start with a letter.
Adds an `IPLiteral` token ahead of `Number` plus a matching `PSLiteral` alternative.

Two deliberate limits on that token:
- **All four octets required**, so it cannot swallow a decimal like `2.5` — decimals stay
  unsupported exactly as before.
- **Added to `PSLiteral` only, not `PSAtom`.** An IP inside an arithmetic expression is
  meaningless; an IP as a flag value is the real case.

**Corpus annotations corrected.** They had gone stale and were actively misleading — the
"manifest miss" group was fixed by case-insensitive cmdlet lookup and now passes both
layers, but the heading still said otherwise. That staleness caused a reader to twice
report those commands as outstanding work when they already passed.

## Result

Session replay: **16/17 clean**, up from 13. The one remaining entry is `Get-WmiObject`,
correctly denied with a redirect to `Get-CimInstance` — the guard rail working, not a gap.

## Testing

`TestIPv4LiteralsParse`, `TestIPLiteralDoesNotShadowExistingTokens` (guards the lexer
ordering against size literals, Windows paths, and `/1GB` arithmetic),
`TestGetPSDriveProviderFlag`, `TestIPLiteralReachesValidator`.

Full suite passes including `-race` and the parser fuzz seeds; `go vet` clean.

## Untested gap

Not exercised against a real Windows or DSLS host — none available. Everything here is
verified against the recorded transcript and unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)