### PR TITLE
Scope the registry to the target host's shell

### DIFF
--- a/manifest/manifests/bzcat.yaml
+++ b/manifest/manifests/bzcat.yaml
@@ -1,6 +1,7 @@
 name: bzcat
 description: Decompress bzip2 files to stdout
 category: filesystem
+shell: bash
 flags: []
 allows_path_args: true
 stdin: true

--- a/manifest/manifests/cat.yaml
+++ b/manifest/manifests/cat.yaml
@@ -1,6 +1,7 @@
 name: cat
 description: Concatenate and print files
 category: filesystem
+shell: bash
 flags:
   - flag: "-n"
     description: "Number all output lines."

--- a/manifest/manifests/cut.yaml
+++ b/manifest/manifests/cut.yaml
@@ -1,6 +1,7 @@
 name: cut
 description: Remove sections from each line
 category: text_processing
+shell: bash
 flags:
   - flag: "-d"
     takes_value: true

--- a/manifest/manifests/df.yaml
+++ b/manifest/manifests/df.yaml
@@ -1,6 +1,7 @@
 name: df
 description: Report file system disk space usage
 category: filesystem
+shell: bash
 flags:
   - flag: "-h"
   - flag: "-i"

--- a/manifest/manifests/dmesg.yaml
+++ b/manifest/manifests/dmesg.yaml
@@ -1,6 +1,7 @@
 name: dmesg
 description: Print or control the kernel ring buffer
 category: system
+shell: bash
 flags:
   - flag: "-T"
 stdin: false

--- a/manifest/manifests/du.yaml
+++ b/manifest/manifests/du.yaml
@@ -1,6 +1,7 @@
 name: du
 description: Estimate file space usage
 category: filesystem
+shell: bash
 flags:
   - flag: "-h"
   - flag: "-s"

--- a/manifest/manifests/file.yaml
+++ b/manifest/manifests/file.yaml
@@ -1,6 +1,7 @@
 name: file
 description: Determine file type
 category: filesystem
+shell: bash
 flags:
   - flag: "-i"
 allows_path_args: true

--- a/manifest/manifests/free.yaml
+++ b/manifest/manifests/free.yaml
@@ -1,6 +1,7 @@
 name: free
 description: Display amount of free and used memory
 category: system
+shell: bash
 flags:
   - flag: "-h"
   - flag: "-m"

--- a/manifest/manifests/grep.yaml
+++ b/manifest/manifests/grep.yaml
@@ -1,6 +1,7 @@
 name: grep
 description: Print lines matching patterns
 category: text_processing
+shell: bash
 regex_arg_position: 0
 flags:
   - flag: "-C"

--- a/manifest/manifests/head.yaml
+++ b/manifest/manifests/head.yaml
@@ -1,6 +1,7 @@
 name: head
 description: Output first part of files
 category: filesystem
+shell: bash
 flags:
   - flag: "-n"
     takes_value: true

--- a/manifest/manifests/iostat.yaml
+++ b/manifest/manifests/iostat.yaml
@@ -1,6 +1,7 @@
 name: iostat
 description: Report CPU and I/O statistics
 category: system
+shell: bash
 flags:
   - flag: "-x"
   - flag: "-m"

--- a/manifest/manifests/iptables.yaml
+++ b/manifest/manifests/iptables.yaml
@@ -1,6 +1,7 @@
 name: iptables
 description: List firewall rules (read-only)
 category: network
+shell: bash
 flags:
   - flag: "-L"
     description: "List rules in a chain"

--- a/manifest/manifests/journalctl.yaml
+++ b/manifest/manifests/journalctl.yaml
@@ -1,6 +1,7 @@
 name: journalctl
 description: Query the systemd journal
 category: logs
+shell: bash
 timeout: 120
 flags:
   - flag: "-u"

--- a/manifest/manifests/last.yaml
+++ b/manifest/manifests/last.yaml
@@ -1,6 +1,7 @@
 name: last
 description: Show listing of last logged in users
 category: logs
+shell: bash
 flags:
   - flag: "-n"
     takes_value: true

--- a/manifest/manifests/ls.yaml
+++ b/manifest/manifests/ls.yaml
@@ -1,6 +1,7 @@
 name: ls
 description: List directory contents
 category: filesystem
+shell: bash
 flags:
   - flag: "-l"
   - flag: "-a"

--- a/manifest/manifests/lsblk.yaml
+++ b/manifest/manifests/lsblk.yaml
@@ -1,6 +1,7 @@
 name: lsblk
 description: List block devices
 category: system
+shell: bash
 flags:
   - flag: "-f"
   - flag: "-a"

--- a/manifest/manifests/lscpu.yaml
+++ b/manifest/manifests/lscpu.yaml
@@ -1,6 +1,7 @@
 name: lscpu
 description: Display CPU architecture information
 category: system
+shell: bash
 flags:
   - flag: "-a"
     description: "Include both online and offline CPUs."

--- a/manifest/manifests/lsof.yaml
+++ b/manifest/manifests/lsof.yaml
@@ -1,6 +1,7 @@
 name: lsof
 description: List open files
 category: process
+shell: bash
 flags:
   - flag: "-i"
   - flag: "-p"

--- a/manifest/manifests/nproc.yaml
+++ b/manifest/manifests/nproc.yaml
@@ -1,6 +1,7 @@
 name: nproc
 description: Print the number of processing units available
 category: system
+shell: bash
 flags:
   - flag: "--all"
   - flag: "--ignore"

--- a/manifest/manifests/pgrep.yaml
+++ b/manifest/manifests/pgrep.yaml
@@ -1,6 +1,7 @@
 name: pgrep
 description: Look up process IDs by name
 category: process
+shell: bash
 flags:
   - flag: "-a"
   - flag: "-f"

--- a/manifest/manifests/ps.yaml
+++ b/manifest/manifests/ps.yaml
@@ -1,6 +1,7 @@
 name: ps
 description: Report process status
 category: process
+shell: bash
 flags:
   - flag: "-e"
   - flag: "-f"

--- a/manifest/manifests/readlink.yaml
+++ b/manifest/manifests/readlink.yaml
@@ -1,6 +1,7 @@
 name: readlink
 description: Print resolved symbolic links
 category: filesystem
+shell: bash
 flags:
   - flag: "-f"
 allows_path_args: true

--- a/manifest/manifests/sort.yaml
+++ b/manifest/manifests/sort.yaml
@@ -1,6 +1,7 @@
 name: sort
 description: Sort lines of text files
 category: text_processing
+shell: bash
 flags:
   - flag: "-n"
   - flag: "-r"

--- a/manifest/manifests/ss.yaml
+++ b/manifest/manifests/ss.yaml
@@ -1,6 +1,7 @@
 name: ss
 description: Investigate sockets
 category: network
+shell: bash
 flags:
   - flag: "-t"
   - flag: "-u"

--- a/manifest/manifests/stat.yaml
+++ b/manifest/manifests/stat.yaml
@@ -1,6 +1,7 @@
 name: stat
 description: Display file or file system status
 category: filesystem
+shell: bash
 flags:
   - flag: "-c"
     takes_value: true

--- a/manifest/manifests/strings.yaml
+++ b/manifest/manifests/strings.yaml
@@ -1,6 +1,7 @@
 name: strings
 description: Print printable strings in files
 category: filesystem
+shell: bash
 flags:
   - flag: "-n"
     takes_value: true

--- a/manifest/manifests/systemctl.yaml
+++ b/manifest/manifests/systemctl.yaml
@@ -1,6 +1,7 @@
 name: systemctl
 description: systemd parent manifest
 category: services
+shell: bash
 flags: []
 stdin: false
 stdout: true

--- a/manifest/manifests/systemctl_is-active.yaml
+++ b/manifest/manifests/systemctl_is-active.yaml
@@ -1,6 +1,7 @@
 name: systemctl_is-active
 description: Check whether units are active
 category: services
+shell: bash
 flags:
   - flag: "--no-pager"
 stdin: false

--- a/manifest/manifests/systemctl_is-enabled.yaml
+++ b/manifest/manifests/systemctl_is-enabled.yaml
@@ -1,6 +1,7 @@
 name: systemctl_is-enabled
 description: Check whether unit files are enabled
 category: services
+shell: bash
 flags:
   - flag: "--no-pager"
 stdin: false

--- a/manifest/manifests/systemctl_list-units.yaml
+++ b/manifest/manifests/systemctl_list-units.yaml
@@ -1,6 +1,7 @@
 name: systemctl_list-units
 description: List units currently in memory
 category: services
+shell: bash
 flags:
   - flag: "--type"
     takes_value: true

--- a/manifest/manifests/systemctl_show.yaml
+++ b/manifest/manifests/systemctl_show.yaml
@@ -1,6 +1,7 @@
 name: systemctl_show
 description: Show properties of one or more units
 category: services
+shell: bash
 flags:
   - flag: "-p"
     takes_value: true

--- a/manifest/manifests/systemctl_status.yaml
+++ b/manifest/manifests/systemctl_status.yaml
@@ -1,6 +1,7 @@
 name: systemctl_status
 description: Show runtime status of one or more units
 category: services
+shell: bash
 flags:
   - flag: "--no-pager"
 stdin: false

--- a/manifest/manifests/tail.yaml
+++ b/manifest/manifests/tail.yaml
@@ -1,6 +1,7 @@
 name: tail
 description: Output last part of files
 category: filesystem
+shell: bash
 flags:
   - flag: "-n"
     takes_value: true

--- a/manifest/manifests/top.yaml
+++ b/manifest/manifests/top.yaml
@@ -1,6 +1,7 @@
 name: top
 description: Display Linux processes in batch mode
 category: process
+shell: bash
 flags:
   - flag: "-b"
   - flag: "-n"

--- a/manifest/manifests/tr.yaml
+++ b/manifest/manifests/tr.yaml
@@ -1,6 +1,7 @@
 name: tr
 description: Translate or delete characters
 category: text_processing
+shell: bash
 flags:
   - flag: "-d"
   - flag: "-s"

--- a/manifest/manifests/uname.yaml
+++ b/manifest/manifests/uname.yaml
@@ -1,6 +1,7 @@
 name: uname
 description: Print system information
 category: system
+shell: bash
 flags:
   - flag: "-a"
   - flag: "-r"

--- a/manifest/manifests/uniq.yaml
+++ b/manifest/manifests/uniq.yaml
@@ -1,6 +1,7 @@
 name: uniq
 description: Report or omit repeated lines
 category: text_processing
+shell: bash
 flags:
   - flag: "-c"
   - flag: "-d"

--- a/manifest/manifests/uptime.yaml
+++ b/manifest/manifests/uptime.yaml
@@ -1,6 +1,7 @@
 name: uptime
 description: Tell how long the system has been running
 category: system
+shell: bash
 flags:
   - flag: "-p"
 stdin: false

--- a/manifest/manifests/vmstat.yaml
+++ b/manifest/manifests/vmstat.yaml
@@ -1,6 +1,7 @@
 name: vmstat
 description: Report virtual memory statistics
 category: system
+shell: bash
 flags:
   - flag: "-s"
 stdin: false

--- a/manifest/manifests/w.yaml
+++ b/manifest/manifests/w.yaml
@@ -1,6 +1,7 @@
 name: w
 description: Show who is logged on and what they are doing
 category: system
+shell: bash
 flags:
   - flag: "-h"
     description: "Suppress the header."

--- a/manifest/manifests/wc.yaml
+++ b/manifest/manifests/wc.yaml
@@ -1,6 +1,7 @@
 name: wc
 description: Print newline, word, and byte counts
 category: filesystem
+shell: bash
 flags:
   - flag: "-l"
   - flag: "-w"

--- a/manifest/manifests/who.yaml
+++ b/manifest/manifests/who.yaml
@@ -1,6 +1,7 @@
 name: who
 description: Show who is logged on
 category: system
+shell: bash
 flags:
   - flag: "-a"
     description: "All information."

--- a/manifest/manifests/xargs.yaml
+++ b/manifest/manifests/xargs.yaml
@@ -1,6 +1,7 @@
 name: xargs
 description: Build and execute commands from stdin
 category: text_processing
+shell: bash
 flags:
   - flag: "-I"
     takes_value: true

--- a/manifest/manifests/xzcat.yaml
+++ b/manifest/manifests/xzcat.yaml
@@ -1,6 +1,7 @@
 name: xzcat
 description: Decompress xz files to stdout
 category: filesystem
+shell: bash
 flags: []
 allows_path_args: true
 stdin: true

--- a/manifest/manifests/zcat.yaml
+++ b/manifest/manifests/zcat.yaml
@@ -1,6 +1,7 @@
 name: zcat
 description: Decompress gzip files to stdout
 category: filesystem
+shell: bash
 flags: []
 allows_path_args: true
 stdin: true

--- a/manifest/manifests/zgrep.yaml
+++ b/manifest/manifests/zgrep.yaml
@@ -1,6 +1,7 @@
 name: zgrep
 description: Search inside gzip-compressed files
 category: text_processing
+shell: bash
 regex_arg_position: 0
 flags:
   - flag: "-i"

--- a/manifest/manifests/zstdcat.yaml
+++ b/manifest/manifests/zstdcat.yaml
@@ -1,6 +1,7 @@
 name: zstdcat
 description: Decompress zstd files to stdout
 category: filesystem
+shell: bash
 flags: []
 allows_path_args: true
 stdin: true

--- a/server/server.go
+++ b/server/server.go
@@ -400,7 +400,12 @@ func (c *Core) Execute(ctx context.Context, in ExecuteInput) (output.CommandResu
 		)
 		return output.CommandResult{}, err
 	}
-	if err := c.Validate(pipeline, c.Registry); err != nil {
+	// Scope the registry to the target host's shell. Without this a Windows
+	// host accepts `ls -la` (it resolves to the POSIX manifest, then fails at
+	// the OS) and a Unix host accepts `Get-Service` — wasted turns in both
+	// directions. Manifests with no shell stay reachable everywhere, so
+	// cross-platform tools like docker and curl are unaffected.
+	if err := c.Validate(pipeline, validator.ScopeRegistry(c.Registry, string(shell))); err != nil {
 		c.logger.InfoContext(ctx, "execute",
 			"command", in.Command,
 			"host", in.Host,

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -56,6 +56,35 @@ func (e *ValidationError) Error() string {
 	return e.Message
 }
 
+// ScopeRegistry returns the subset of registry usable on a host running shell.
+//
+// A manifest's `shell` field is three-way:
+//
+//	shell: bash        Unix only — ls, df, uname, systemctl
+//	shell: powershell  Windows only — Get-Service, netstat, DSCheckLS.exe
+//	absent             universal — docker, curl, python, aws, psql
+//
+// Absent means universal rather than POSIX, which is what keeps `docker ps`
+// working on a Windows host. Only a manifest that explicitly names a *different*
+// shell is filtered out, so marking is additive: an unmarked Unix-only manifest
+// stays reachable everywhere until someone marks it, and nothing breaks in the
+// meantime.
+//
+// An empty shell means the host's dialect is unknown — the standalone validate
+// tool has no connection — and returns the registry unchanged.
+func ScopeRegistry(registry map[string]*manifest.Manifest, shell string) map[string]*manifest.Manifest {
+	if shell == "" {
+		return registry
+	}
+	scoped := make(map[string]*manifest.Manifest, len(registry))
+	for name, m := range registry {
+		if m == nil || m.Shell == "" || m.Shell == shell {
+			scoped[name] = m
+		}
+	}
+	return scoped
+}
+
 func ValidatePipeline(pipeline *parser.Pipeline, registry map[string]*manifest.Manifest) error {
 	for i, seg := range pipeline.Segments {
 		if err := validateSegment(seg, registry, i == 0); err != nil {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -789,3 +789,57 @@ func TestFlagBundlingStaysOptIn(t *testing.T) {
 		}
 	}
 }
+
+// TestScopeRegistryByShell covers the three-way shell field. A Windows host
+// accepting `ls -la` (it resolves to the POSIX manifest, then fails at the OS)
+// wasted exactly the turns this guard rail exists to save.
+func TestScopeRegistryByShell(t *testing.T) {
+	full := testRegistry(t)
+	accepted := func(shell, cmd string, args ...string) bool {
+		p := &parser.Pipeline{Segments: []parser.PipelineSegment{{Command: cmd, Args: args}}}
+		return ValidatePipeline(p, ScopeRegistry(full, shell)) == nil
+	}
+
+	cases := []struct {
+		cmd        []string
+		ps, bash   bool
+		note       string
+	}{
+		{[]string{"ls", "-la"}, false, true, "unix-only"},
+		{[]string{"cat", "-n", "/x"}, false, true, "unix-only"},
+		{[]string{"df", "-h"}, false, true, "unix-only"},
+		{[]string{"systemctl", "status"}, false, true, "unix-only via subcommand manifest"},
+		{[]string{"get-service"}, true, false, "windows-only"},
+		{[]string{"netstat", "-ano"}, true, false, "windows-only"},
+		{[]string{"dscheckls.exe", "-l"}, true, false, "windows-only"},
+		{[]string{"docker", "ps"}, true, true, "universal"},
+		{[]string{"curl", "-I", "https://x"}, true, true, "universal"},
+		{[]string{"psql", "-c", "SELECT 1"}, true, true, "universal"},
+		{[]string{"aws", "ec2", "describe-instances"}, true, true, "universal"},
+		{[]string{"kubectl", "get", "pods"}, true, true, "universal"},
+	}
+	for _, tc := range cases {
+		if got := accepted("powershell", tc.cmd[0], tc.cmd[1:]...); got != tc.ps {
+			t.Errorf("powershell %v (%s): accepted=%v want %v", tc.cmd, tc.note, got, tc.ps)
+		}
+		if got := accepted("bash", tc.cmd[0], tc.cmd[1:]...); got != tc.bash {
+			t.Errorf("bash %v (%s): accepted=%v want %v", tc.cmd, tc.note, got, tc.bash)
+		}
+	}
+}
+
+// An unknown shell must not filter anything: the standalone validate tool has
+// no connection and therefore no dialect to scope to.
+func TestScopeRegistryUnknownShellIsPermissive(t *testing.T) {
+	full := testRegistry(t)
+	scoped := ScopeRegistry(full, "")
+	if len(scoped) != len(full) {
+		t.Errorf("ScopeRegistry(_, \"\") returned %d entries, want all %d", len(scoped), len(full))
+	}
+	for _, cmd := range []string{"ls", "get-service"} {
+		p := &parser.Pipeline{Segments: []parser.PipelineSegment{{Command: cmd}}}
+		if err := ValidatePipeline(p, scoped); err != nil {
+			t.Errorf("unknown shell should accept %q: %v", cmd, err)
+		}
+	}
+}


### PR DESCRIPTION
## Why

A Windows host accepted `ls -la` — it resolved to the POSIX manifest, then failed at the
OS. A Unix host accepted `Get-Service` the same way. Both burn exactly the turns this
guard rail exists to save, and the fuzzy suggester compounded it by proposing commands
from the wrong dialect.

## The load-bearing decision

The obvious fix — filter POSIX manifests on Windows and vice versa — is **wrong**. It
would break `docker`, `kubectl`, `aws`, `svn`, `curl`, `wget`, `python`, `node`, and
`psql` on Windows hosts, all of which run fine under PowerShell. The registry is 181 POSIX
to 104 PowerShell, and the POSIX set is a mix of Unix-only and cross-platform.

So the `shell` field becomes three-way:

| Value | Meaning | Examples |
|---|---|---|
| `shell: bash` | Unix only | `ls`, `df`, `uname`, `systemctl` |
| `shell: powershell` | Windows only | `Get-Service`, `netstat`, `DSCheckLS.exe` |
| *absent* | **universal** | `docker`, `curl`, `python`, `aws`, `psql` |

Absent means universal, not POSIX. Only a manifest naming a *different* shell is filtered,
so marking is **additive**: an unmarked Unix-only manifest stays reachable everywhere until
someone marks it, and nothing breaks in the meantime.

## Implementation

A registry filter at the entry point (`ScopeRegistry`), not a shell parameter threaded
through `validateSegment`, `validateSudo`, `validateXargs`, `validateSubcommand`,
`lookupManifest`, and `closestCmdlet`. Lookup and the suggester then only ever see
in-dialect manifests.

No signature churn: `ValidatePipeline` is unchanged, and `Core.Validate` keeps its type so
the eight test injection sites still compile. `Execute` already computed the shell three
lines above the validate call to pick the parser — it simply wasn't passing it.

Marks 47 manifests, **including the `systemctl_*` subcommand manifests**. That one was
found by testing, not reasoning: `systemctl status` resolves to `systemctl_status`, so
marking only the parent left it reachable on Windows.

An unknown shell filters nothing, so the standalone `validate` tool — which has no
connection and therefore no dialect — is unaffected.

## Testing

`TestScopeRegistryByShell` asserts all three categories in both directions (12 commands ×
2 shells). `TestScopeRegistryUnknownShellIsPermissive` pins the no-connection case.
3DX session replay still runs 16/17 under PowerShell scoping — no regression.

Full suite passes including `-race`; `go vet` clean.

## Known limit

Marking is incomplete by design. 47 of ~181 POSIX manifests are marked — the ones that
cause false-accepts today. The rest stay universal and therefore still reachable on
Windows. That is safe (nothing breaks) but not finished; the remainder can be marked as
they surface.

No real Windows host available, so this is verified against the recorded transcript and
unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)